### PR TITLE
Add subformat in list type

### DIFF
--- a/jsonschema2popo/jsonschema2popo.py
+++ b/jsonschema2popo/jsonschema2popo.py
@@ -323,6 +323,7 @@ class JsonSchema2Popo:
     def type_parser(self, t):
         _type = None
         _subtype = None
+        _subformat = None
         if "type" in t:
             if t["type"] == "array" and "items" in t:
                 self.list_used = True
@@ -330,6 +331,8 @@ class JsonSchema2Popo:
                 if isinstance(t["items"], list):
                     if "type" in t["items"][0]:
                         _subtype = self.J2P_TYPES[t["items"][0]["type"]]
+                        if "format" in t["items"][0]:
+                            _subformat = t["items"][0]["format"]
                     elif (
                         "$ref" in t["items"][0]
                         or "oneOf" in t["items"][0]
@@ -343,6 +346,8 @@ class JsonSchema2Popo:
                 elif isinstance(t["items"], dict):
                     if "type" in t["items"]:
                         _subtype = self.J2P_TYPES[t["items"]["type"]]
+                        if "format" in t["items"]:
+                            _subformat = t["items"]["format"]
                     elif (
                         "$ref" in t["items"]
                         or "oneOf" in t["items"]
@@ -368,7 +373,7 @@ class JsonSchema2Popo:
             _type = t["$ref"].split("/")[-1]
         elif "anyOf" in t or "allOf" in t or "oneOf" in t:
             _type = list
-        return {"type": _type, "subtype": _subtype}
+        return {"type": _type, "subtype": _subtype, "subformat": _subformat}
 
     def write_file(self, filename):
         template = self.custom_template or self.TEMPLATES[self.language]


### PR DESCRIPTION
We needed that change for our custom templates. 
As of today, this is useless to the default templates of this project.
However, since there is a support for custom templates, I think other users might need this change as well.
Feel free to merge it/close it.
Cheers


### Description

In a similar way of JSONSchema2Pojo does, we have created templates for JsonSchema2PoPo2 with native standard types for different string formats described in JsonSchema Draft 7 (and 8) including datetime, date, time, uuid,...

As consequence, type and format are mandatory to select the right programming type.

However, in the case of lists, the type of elements is available (named as subtype) but not the format.
The goal of this PR is to add the subformat in list type to be able to handle list of other types than numbers and strings.
