### PR TITLE
Fix #8

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.2.3
+
+- Fix for #8 with #9. Enum generation now works in the root object
+
 ## 2.2.2
 
 - Added `--version` option

--- a/jsonschema2popo/__init__.py
+++ b/jsonschema2popo/__init__.py
@@ -1,3 +1,3 @@
 #!/usr/bin/env python
 
-__version__ = "2.2.2"
+__version__ = "2.2.3"

--- a/jsonschema2popo/js_class.tmpl
+++ b/jsonschema2popo/js_class.tmpl
@@ -206,7 +206,7 @@ Object.defineProperty({{ model.parent or model.name }}, "optionsFlipped", {
  * @readonly
  */
 Object.defineProperty({{ model.parent or model.name }}, "{{ name }}", {
-    value: new {{ model.name }}({% if model.text_type == "string" %}"{{value}}"{% elif model.text_type == "integer" or model.text_type == "number" %}{{value}}{% endif %})
+    value: new {{ model.parent or model.name }}({% if model.text_type == "string" %}"{{value}}"{% elif model.text_type == "integer" or model.text_type == "number" %}{{value}}{% endif %})
 });
 {% endfor %}
 {% endif %}

--- a/jsonschema2popo/jsonschema2popo.py
+++ b/jsonschema2popo/jsonschema2popo.py
@@ -266,7 +266,7 @@ class JsonSchema2Popo:
 
                     # Only generate sub models when the sub model actually has properties, otherwise treat is as
                     # a dict, which is what an object is to JSON
-                    if sub_mod["properties"]:
+                    if sub_mod["properties"] or "enum" in sub_mod:
                         model["subModels"].append(sub_mod)
                     else:
                         _type = {

--- a/test/go/root_basic_generation.go
+++ b/test/go/root_basic_generation.go
@@ -13,5 +13,6 @@ func Test() {
 		ListInt: []int64{0, 1, 2},
 		String:  "ABC",
 		Object:  map[string]interface{}{"A": "X"},
+		StringEnum: generated.Abcd_StringEnumOptions.A,
 	}
 }

--- a/test/test_js.js
+++ b/test/test_js.js
@@ -47,6 +47,7 @@ f.test_jsonschema2popo_test_root_basic_generation = (filename) => {
             "ListInt": [0, 1, 2],
             "String": "ABC",
             "Object": {"A": "X"},
+            "StringEnum": "A"
         }
     );
     assertEquals(a.Int, 0);
@@ -54,6 +55,7 @@ f.test_jsonschema2popo_test_root_basic_generation = (filename) => {
     assertEquals(a.ListInt, [0, 1, 2]);
     assertEquals(a.String, "ABC");
     assertEquals(a.Object, {"A": "X"});
+    assertEquals(a.StringEnum.asMap(), "A");
 
     assertThrows(
         Error, "Int must be Number", () => foo.Abcd.fromMap({"Int": true})
@@ -75,6 +77,9 @@ f.test_jsonschema2popo_test_root_basic_generation = (filename) => {
     )
     assertThrows(
         Error, "String must be String", () => foo.Abcd.fromMap({"String": 0})
+    )
+    assertThrows(
+        Error, "Value must be one of the enumerated options", () => new foo.Abcd._StringEnum("abc")
     )
 }
 

--- a/test/test_jsonschema2popo.py
+++ b/test/test_jsonschema2popo.py
@@ -177,6 +177,10 @@ class JsonSchema2Popo(unittest.TestCase):
                 },
                 "Object": {
                     "type": "object"
+                },
+                "StringEnum": {
+                    "type": "string",
+                    "enum": ["A", "b", "c"]
                 }
             }
         }"""
@@ -191,6 +195,7 @@ class JsonSchema2Popo(unittest.TestCase):
                 "ListInt": [0, 1, 2],
                 "String": "ABC",
                 "Object": {"A": "X"},
+                "StringEnum": "A",
             }
         )
         self.assertEqual(a.Int, 0)
@@ -198,6 +203,7 @@ class JsonSchema2Popo(unittest.TestCase):
         self.assertEqual(a.ListInt, [0, 1, 2])
         self.assertEqual(a.String, "ABC")
         self.assertEqual(a.Object, {"A": "X"})
+        self.assertEqual(a.StringEnum.value, "A")
 
         self.assertRaisesRegex(
             TypeError, "Int must be int", lambda: foo.Abcd.from_dict({"Int": 0.1})
@@ -219,6 +225,11 @@ class JsonSchema2Popo(unittest.TestCase):
         )
         self.assertRaisesRegex(
             TypeError, "String must be str", lambda: foo.Abcd.from_dict({"String": 0})
+        )
+        self.assertRaisesRegex(
+            ValueError,
+            "is not a valid .*_StringEnum",
+            lambda: foo.Abcd._StringEnum.from_dict({"String": 0}),
         )
 
     def test_root_string_enum(self):


### PR DESCRIPTION
Resolve #8 by checking if an object is an enum before overwriting the `_type` field. Also fixes root enum generation in JS.